### PR TITLE
Integrate azure ad groups with keyvault - Breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Module key vault
+
+This is a terraform module for creating an azure key vault resource
+
+## Usage
+```
+module "claim-store-vault" {
+  source              = "git@github.com:contino/moj-module-key-vault?ref=master"
+  name                = "rhubarb-fe-${var.env}" // Max 24 characters
+  product             = "${var.product}"
+  env                 = "${var.env}"
+  tenant_id           = "${var.tenant_id}"
+  object_id           = "${var.jenkins_AAD_objectId}"
+  resource_group_name = "${module.<another-module>.resource_group_name}"
+  product_group_object_id = "<uuid>"
+}
+```
+
+### product_group_object_id
+The product group object id is the Azure AD group object_id of users
+who should be allowed to write secrets into the vault
+(note they can't read the secrets after writing).
+
+Useful commands for finding your group object id:
+
+List all reform groups:
+```bash
+$ az ad group list --query "[?contains(displayName, 'dcd_')].{DisplayName: displayName, ObjectID: objectId}" -o table
+```
+
+Retrieve by name if you know the display name:
+```bash
+$ az ad group list --query "[?displayName=='dcd_devops'].{DisplayName: displayName, ObjectID: objectId}" -o table
+```

--- a/main.tf
+++ b/main.tf
@@ -5,8 +5,8 @@ locals {
 }
 
 resource "azurerm_key_vault" "kv" {
-  name                = "${local.vaultName}"
-  location            = "${var.location}"
+  name = "${local.vaultName}"
+  location = "${var.location}"
   resource_group_name = "${var.resource_group_name}"
 
   sku {
@@ -50,6 +50,37 @@ resource "azurerm_key_vault" "kv" {
       "list",
       "get",
       "delete",
+    ]
+  }
+
+  access_policy {
+    object_id = "${var.product_group_object_id}"
+    tenant_id = "${var.tenant_id}"
+
+    key_permissions = [
+      "list",
+      "update",
+      "create",
+      "import",
+      "delete"
+    ]
+    certificate_permissions = [
+      "list",
+      "update",
+      "create",
+      "import",
+      "delete",
+      "managecontacts",
+      "manageissuers",
+      "getissuers",
+      "listissuers",
+      "setissuers",
+      "deleteissuers"
+    ]
+    secret_permissions = [
+      "list",
+      "set",
+      "delete"
     ]
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -40,3 +40,6 @@ variable "location" {
     description                 = "The name of the Azure region to deploy your vault to. Please use the default by not passing this parameter unless instructed otherwise."
 }
 
+variable "product_group_object_id" {
+    description = "The AD group of users that should have access to add secrets to the key vault, see the README on where to find this"
+}


### PR DESCRIPTION
Gives write and list access to azure keyvault for the product team that consumes this module
No read access is provided

Docs are updated

This is a breaking change as I couldn't see a way to add a new access policy with out breaking it

Test evidence:

https://sandbox-build.platform.hmcts.net/job/HMCTS/job/cmc-claim-store/job/cnp/47/console

https://portal.azure.com/#resource/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/cmc-claim-store-saat/providers/Microsoft.KeyVault/vaults/cmc-claim-store-saat/access_policies

![image](https://user-images.githubusercontent.com/21194782/36418015-8050ebbe-1625-11e8-8202-27267f7a72d3.png)

