### PR TITLE
DTSPO-29659 - Create keyvault access policy for env specific Jenkins identity

### DIFF
--- a/jenkins-access.tf
+++ b/jenkins-access.tf
@@ -1,0 +1,52 @@
+data "azurerm_user_assigned_identity" "jenkins" {
+  name                = "jenkins-${var.env}-mi"
+  resource_group_name = "managed-identities-${var.env}-rg"
+}
+
+resource "azurerm_key_vault_access_policy" "jenkins" {
+  key_vault_id = azurerm_key_vault.kv.id
+  object_id = data.azurerm_user_assigned_identity.jenkins.principal_id
+  tenant_id = data.azurerm_client_config.current.tenant_id
+
+  certificate_permissions = [
+    "Create",
+    "Delete",
+    "DeleteIssuers",
+    "Get",
+    "GetIssuers",
+    "Import",
+    "List",
+    "ListIssuers",
+    "SetIssuers",
+    "Update",
+    "ManageContacts",
+    "ManageIssuers",
+  ]
+
+  key_permissions = [
+    "Create",
+    "List",
+    "Get",
+    "Delete",
+    "Update",
+    "Import",
+    "Backup",
+    "Restore",
+    "Decrypt",
+    "Encrypt",
+    "UnwrapKey",
+    "WrapKey",
+    "Sign",
+    "Verify",
+    "GetRotationPolicy",
+  ]
+
+  secret_permissions = [
+    "Set",
+    "List",
+    "Get",
+    "Delete",
+    "Recover",
+    "Purge",
+  ]
+}

--- a/jenkins-access.tf
+++ b/jenkins-access.tf
@@ -1,7 +1,8 @@
 resource "azurerm_key_vault_access_policy" "jenkins" {
+  count        = var.jenkins_object_id != "" ? 1 : 0
   key_vault_id = azurerm_key_vault.kv.id
-  object_id = var.jenkins_object_id
-  tenant_id = data.azurerm_client_config.current.tenant_id
+  object_id    = var.jenkins_object_id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
 
   certificate_permissions = [
     "Create",

--- a/jenkins-access.tf
+++ b/jenkins-access.tf
@@ -1,6 +1,6 @@
 data "azurerm_user_assigned_identity" "jenkins" {
-  name                = "jenkins-${var.env}-mi"
-  resource_group_name = "managed-identities-${var.env}-rg"
+  name                = "jenkins-ptlsbox-mi"
+  resource_group_name = "managed-identities-ptlsbox-rg"
 }
 
 resource "azurerm_key_vault_access_policy" "jenkins" {

--- a/jenkins-access.tf
+++ b/jenkins-access.tf
@@ -1,11 +1,6 @@
-data "azurerm_user_assigned_identity" "jenkins" {
-  name                = "jenkins-cftptl-intsvc-mi"
-  resource_group_name = "managed-identities-cftptl-intsvc-rg"
-}
-
 resource "azurerm_key_vault_access_policy" "jenkins" {
   key_vault_id = azurerm_key_vault.kv.id
-  object_id = data.azurerm_user_assigned_identity.jenkins.principal_id
+  object_id = var.jenkins_object_id
   tenant_id = data.azurerm_client_config.current.tenant_id
 
   certificate_permissions = [

--- a/jenkins-access.tf
+++ b/jenkins-access.tf
@@ -1,6 +1,6 @@
 data "azurerm_user_assigned_identity" "jenkins" {
-  name                = "jenkins-ptl-mi"
-  resource_group_name = "managed-identities-ptl-rg"
+  name                = "jenkins-cftptl-intsvc-mi"
+  resource_group_name = "managed-identities-cftptl-intsvc-rg"
 }
 
 resource "azurerm_key_vault_access_policy" "jenkins" {

--- a/jenkins-access.tf
+++ b/jenkins-access.tf
@@ -1,6 +1,6 @@
 data "azurerm_user_assigned_identity" "jenkins" {
-  name                = "jenkins-ptlsbox-mi"
-  resource_group_name = "managed-identities-ptlsbox-rg"
+  name                = "jenkins-ptl-mi"
+  resource_group_name = "managed-identities-ptl-rg"
 }
 
 resource "azurerm_key_vault_access_policy" "jenkins" {

--- a/variables.tf
+++ b/variables.tf
@@ -110,3 +110,8 @@ variable "additional_managed_identities_access" {
   type    = list(string)
   default = []
 }
+
+variable "jenkins_object_id" {
+  description = "The object ID of the environment specific Jenkins managed identity"
+  default     = ""
+}


### PR DESCRIPTION
Update module so an access policy is created for the environment specific jenkins managed identity

Currently an optional value so it continues to work.

Jenkins managed identity can be passed to the module using the `jenkins_object_id` variable
