### PR TITLE
feat: allow using keyvault with private networking

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ resource "azurerm_key_vault" "kv" {
   enabled_for_template_deployment = true
   soft_delete_retention_days      = 90
   purge_protection_enabled        = var.purge_protection_enabled
+  public_network_access_enabled   = var.public_network_access_enabled
 
   network_acls {
     bypass                     = "AzureServices"

--- a/variables.tf
+++ b/variables.tf
@@ -97,6 +97,12 @@ variable "purge_protection_enabled" {
   default = true
 }
 
+variable "public_network_access_enabled" {
+  description = "Whether public network access is allowed for this Key Vault. Set to false when using a private endpoint."
+  type        = bool
+  default     = true
+}
+
 variable "private_endpoint_subnet_id" {
   description = "Subnet ID to attach private endpoint to - overrides the default subnet id"
   default     = null


### PR DESCRIPTION
Notes:
* Make `public_network_access_enabled` configurable by consumers
* This was defaulting to `true` which is not desired in cases where you want to lock down network access to private endpoint only
* Keeping default value as `true` so will be no disruption to existing consumers
